### PR TITLE
overwriting osfamily and operatingsystemrelease values for Amazon Linux

### DIFF
--- a/lib/facter/operatingsystemrelease.rb
+++ b/lib/facter/operatingsystemrelease.rb
@@ -1,0 +1,21 @@
+# Fact: osfamily
+#
+# Purpose: Returns the operating system
+#
+# Resolution:
+#   if the operating system is Amazon, get the operating system release from /etc/system-release
+# Caveats:
+#   This fact is completely reliant on the operatingsystem fact, and no
+#   heuristics are used
+#
+
+Facter.add(:operatingsystemrelease) do
+  has_weight 100
+  setcode do
+    case Facter.value(:operatingsystem)
+    when "Amazon"
+        lines = File.open("/etc/system-release").to_a
+        value = lines.first.split(" ")[-1]
+    end
+  end
+end

--- a/lib/facter/osfamily.rb
+++ b/lib/facter/osfamily.rb
@@ -1,0 +1,19 @@
+# Fact: osfamily
+#
+# Purpose: Returns the operating system of Amazon linux as 'Redhat'
+# Resolution:
+#   if the operating system is Amazon, report the osfamily as 'Redhat'
+# Caveats:
+#   This fact is completely reliant on the operatingsystem fact, and no
+#   heuristics are used
+#
+
+Facter.add(:osfamily) do
+  has_weight 100
+  setcode do
+    case Facter.value(:operatingsystem)
+    when "Amazon"
+      "RedHat"
+    end
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,7 +44,7 @@ class install_collectd {
         }
   
         default: {
-            fail("${::osfamily} is not supported.")
+            fail("Your osfamily : ${::osfamily} is not supported.")
         }
     }
 }

--- a/manifests/install_repo.pp
+++ b/manifests/install_repo.pp
@@ -24,21 +24,21 @@ class install_collectd::install_repo inherits install_collectd::repo_params {
             if $::operatingsystemmajrelease == '5' {
                     exec { 'install SignalFx repo  on centos 5':
                     command     => "yum -y install wget &&
-                                   wget ${::repo_source} &&
-                                   yum -y install --nogpgcheck ${::repo_name} &&
-                                   rm -f ${::repo_name}"
+                                   wget ${install_collectd::repo_params::repo_source} &&
+                                   yum -y install --nogpgcheck ${install_collectd::repo_params::repo_name} &&
+                                   rm -f ${install_collectd::repo_params::repo_name}"
                     }
             }
             else {
-                    package { $::repo_name:
+                    package { $install_collectd::repo_params::repo_name:
                             ensure      => latest,
                             provider    => 'rpm',
-                            source      => $::repo_source
+                            source      => $install_collectd::repo_params::repo_source
                     }
             }
         }
         default: {
-              fail("${::osfamily} is not supported.")
+              fail("Your osfamily : ${::osfamily} is not supported.")
         }
     }
 

--- a/manifests/repo_params.pp
+++ b/manifests/repo_params.pp
@@ -18,7 +18,7 @@ class install_collectd::repo_params {
                                       $repo_source     = 'https://s3.amazonaws.com/public-downloads--signalfuse-com/rpms/SignalFx-rpms/release/SignalFx-RPMs-centos-5-release-1.0-0.noarch.rpm'
         }
                                 default: {
-                                        fail("${::operatingsystemmajrelease} is not supported.")
+                                        fail("Your centos os major release : ${::operatingsystemmajrelease} is not supported.")
                                 }
                         }
                 }
@@ -33,12 +33,12 @@ class install_collectd::repo_params {
                                       $repo_source     = 'https://dl.signalfx.com/rpms/SignalFx-rpms/release/SignalFx-RPMs-AWS_EC2_Linux_2014_09-release-1.0-0.noarch.rpm'
                                 }
                                 default: {
-                                      fail("${::operatingsystemrelease} is not supported.")
+                                      fail("Your operating system release : ${::operatingsystemrelease} is not supported.")
                                 }
                         }
                 }
                 default: {
-                        fail("${::operatingsystem} is not supported.")
+                        fail("Your operating system : ${::operatingsystem} is not supported.")
                 }
         }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "signalfx-install_collectd",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Uday Sagar Shiramshetty",
   "summary": "A puppet module that just installs collectd from SignalFx repositories",
   "license": "Apache-2.0",
@@ -43,7 +43,7 @@
     }
   ],
   "dependencies": [
-    {"name":"pdxcat/collectd","version_requirement":">= 4.0.0"},
+    {"name":"puppet/collectd","version_requirement":">= 4.0.0"},
     {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0"},
     {"name":"puppetlabs/concat","version_requirement":">= 1.0.4"}
   ]


### PR DESCRIPTION
updated variable names and fail messages
updated dependency from pdxcat/collectd to puppet/collectd
increased version number from 0.1.2 to 0.1.3
